### PR TITLE
fix: typo in access-token.mdx: cliams -> claims

### DIFF
--- a/src/articles/access-token.mdx
+++ b/src/articles/access-token.mdx
@@ -11,7 +11,7 @@ An access token is a credential, typically a string of characters, that is used 
 Although the RFCs for OAuth 2.0 and OIDC don't specify the implementation details of access tokens, there are two common types of access tokens used in practice:
 
 - <Ref slug="opaque-token" />: A random string that has no meaning ("opaque") to the client. The client presents the token to the resource server, which validates the token with the authorization server.
-- <Ref slug="jwt" />: A self-contained token that contains <Ref slug="claim">cliams</Ref> (e.g., user ID, expiration time) with a digital signature. The resource server can validate the token without making an additional request to the authorization server.
+- <Ref slug="jwt" />: A self-contained token that contains <Ref slug="claim">claims</Ref> (e.g., user ID, expiration time) with a digital signature. The resource server can validate the token without making an additional request to the authorization server.
 
 ## How does an access token work?
 


### PR DESCRIPTION
Fixes a typo in access-token.mdx. Changes cliams to claims.

