### PR TITLE
fix: typo in authorization-code-flow.mdx

### DIFF
--- a/src/articles/authorization-code-flow.mdx
+++ b/src/articles/authorization-code-flow.mdx
@@ -1,7 +1,7 @@
 ---
 title: Authorization code flow
 tags: [oauth 2.0, oidc]
-description: The authorization code dlow is a secure OAuth 2.0 mechanism that enables applications to obtain access tokens on behalf of users. It involves user authentication, authorization code generation, and token exchange.
+description: The authorization code flow is a secure OAuth 2.0 mechanism that enables applications to obtain access tokens on behalf of users. It involves user authentication, authorization code generation, and token exchange.
 ---
 
 ## What is authorization code flow?


### PR DESCRIPTION
Fixes a typo in authorization-code-flow.mdx. Changes dlow to flow.