### PR TITLE
refactor: fix canonical urls

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,14 @@ const locale = getLocale(Astro.url);
 const phrases = getPhrases(locale);
 const title = props.title ? `${props.title} · Auth Wiki` : "Auth Wiki";
 const description = props.description ?? phrases.site.description;
-const canonical = new URL(Astro.url.pathname, Astro.site).href;
+// Needs to remove the file extension from the URL since Astro will add it in production when
+// build format is set to "file".
+const canonical = new URL(
+  Astro.url.pathname.endsWith(".html")
+    ? Astro.url.pathname.slice(0, -5)
+    : Astro.url.pathname,
+  Astro.site,
+).href;
 ---
 
 <!doctype html>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
canonical urls are not correct:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/1e2a7f48-c4ac-4ce7-b00d-ce22f87968eb">

test after merge.
