### PR TITLE
chore: use internal mermaid-isomorphic

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
     "typescript": "^5.5.4",
     "vitest": "^2.1.4",
     "wrangler": "^3.83.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "mermaid-isomorphic": "github:silverhand-io/mermaid-isomorphic#c081c30"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  mermaid-isomorphic: github:silverhand-io/mermaid-isomorphic#c081c30
+
 importers:
 
   .:
@@ -2263,8 +2266,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid-isomorphic@3.0.0:
-    resolution: {integrity: sha512-6RBUQD0ZWzBHO4KZ8JMK3a/lNL7383N6K4nXzOdA2Ylnhz34qC8Nls2ZgOJVjGuB9Iq1bP61XKE0K/fNOD2n6g==}
+  mermaid-isomorphic@https://codeload.github.com/silverhand-io/mermaid-isomorphic/tar.gz/c081c30:
+    resolution: {tarball: https://codeload.github.com/silverhand-io/mermaid-isomorphic/tar.gz/c081c30}
+    version: 3.0.0
     peerDependencies:
       playwright: '1'
     peerDependenciesMeta:
@@ -5979,7 +5983,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid-isomorphic@3.0.0(playwright@1.48.2):
+  mermaid-isomorphic@https://codeload.github.com/silverhand-io/mermaid-isomorphic/tar.gz/c081c30(playwright@1.48.2):
     dependencies:
       '@fortawesome/fontawesome-free': 6.6.0
       mermaid: 11.3.0
@@ -6613,7 +6617,7 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.2
-      mermaid-isomorphic: 3.0.0(playwright@1.48.2)
+      mermaid-isomorphic: https://codeload.github.com/silverhand-io/mermaid-isomorphic/tar.gz/c081c30(playwright@1.48.2)
       mini-svg-data-uri: 1.4.4
       space-separated-tokens: 2.0.2
       unified: 11.0.5


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

`mermaid-isomorphic` uses playwright, and the playwright default timeout is 30s which produces occasional timeouts when building since we have many mermaid diagrams.

the internal version of `mermaid-isomorphic` increases the timeout to 300s to avoid this issue.