### PR TITLE
refactor: use ascii representation for sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@astrojs/sitemap": "^3.2.1",
     "@astrolib/seo": "1.0.0-beta.8",
     "@vitest/coverage-v8": "2.1.5",
+    "any-ascii": "^0.3.2",
     "arg": "^5.0.2",
     "astro": "^4.13.1",
     "astro-i18n-aut": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 2.1.5
         version: 2.1.5(vitest@2.1.4(@types/node@22.7.7))
+      any-ascii:
+        specifier: ^0.3.2
+        version: 0.3.2
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -1084,6 +1087,10 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  any-ascii@0.3.2:
+    resolution: {integrity: sha512-ABw9wA6PpMfmBbn5eeoOHJV86uqOcjEiuik6zV3dHCBfXu8kKWaCnKnrgzu9hLiFhvZYhdrRdVSo2RjjVhSycw==}
+    engines: {node: '>=12.20'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -4482,6 +4489,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  any-ascii@0.3.2: {}
 
   anymatch@3.1.3:
     dependencies:

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import { getPhrases } from "../phrases";
 import { getCollection } from "astro:content";
 import { defaultLocale } from "astro-i18n-aut";
 import { getLocaleFromUrl } from "../utils/locale";
+import anyAscii from "any-ascii";
 import cover from "../assets/cover.png";
 
 const locale = getLocaleFromUrl(Astro.url);
@@ -30,13 +31,19 @@ const entries = defaultEntries.map((entry) => {
 
 const sections = entries
   .slice()
-  .sort((a, b) => a.data.title.localeCompare(b.data.title))
+  .sort((a, b) =>
+    anyAscii(a.data.title)
+      .toLowerCase()
+      .localeCompare(anyAscii(b.data.title).toLowerCase()),
+  )
   .reduce(
     (acc, article) => {
-      const firstLetter = article.data.title[0]?.toUpperCase();
+      const firstLetter = anyAscii(article.data.title)[0]?.toUpperCase();
 
       if (!firstLetter) {
-        return acc;
+        throw new Error(
+          `No first letter found for article ${article.data.title}`,
+        );
       }
 
       if (!acc[firstLetter]) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

non-English titles should be categorized by their ascii representations, rather than the first letter. resolves #56.