### PR TITLE
chore: revert back to use unified Node and pnpm setup action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,18 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4.4.0
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v6
+      - name: Setup Node and pnpm
+        uses: silverhand-io/actions-node-pnpm-run-steps@v5
         with:
           node-version: 22.23.1
-          registry-url: https://registry.npmjs.org/
-          cache: 'pnpm'
+          pnpm-version: 10
 
       - name: Build
-        run: pnpm i && pnpm build
+        run: pnpm build
 
       - name: Deploy
         uses: cloudflare/wrangler-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,18 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4.4.0
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v6
+      - name: Setup Node and pnpm
+        uses: silverhand-io/actions-node-pnpm-run-steps@v5
         with:
           node-version: 22.23.1
-          registry-url: https://registry.npmjs.org/
-          cache: 'pnpm'
+          pnpm-version: 10
 
       - name: Build
-        run: pnpm i && pnpm build
+        run: pnpm build
 
       - name: Test
         run: pnpm test


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Revert back to use `silverhand-io/actions-node-pnpm-run-steps@v5` and specify Node and pnpm versions