### PR TITLE
chore: migrate pnpm settings to pnpm-workspace.yaml and upgrade typescript to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "private": true,
   "version": "0.0.1",
+  "engines": {
+    "pnpm": "^10.0.0"
+  },
   "scripts": {
     "prepare": "playwright install --with-deps chromium",
     "dev": "astro dev",
@@ -27,7 +30,6 @@
     "astro": "^7.0.6",
     "astro-i18n-aut": "^0.7.3",
     "astro-icon": "^1.1.5",
-    "commander": "^13.0.0",
     "dotenv": "^17.4.2",
     "listr2": "^10.2.2",
     "open-graph-scraper": "^6.8.2",
@@ -37,28 +39,9 @@
     "playwright": "1.61.1",
     "rehype-mermaid": "^3.0.0",
     "remark-custom-header-id": "^1.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.0",
     "undici": "^8.7.0",
     "vitest": "4.1.9",
     "wrangler": "^3.114.17"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp",
-      "workerd"
-    ],
-    "overrides": {
-      "esbuild@<0.25.0": "^0.25.0",
-      "mermaid-isomorphic": "github:silverhand-io/mermaid-isomorphic#c081c30",
-      "undici@<6.27.0": "^6.27.0",
-      "ws@>=8.0.0 <8.21.0": "^8.21.0"
-    },
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "astro-i18n-aut>astro": "^7.0.0",
-        "@astrolib/seo>astro": "^7.0.0"
-      }
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
-        version: 0.9.9(prettier@3.9.4)(typescript@5.9.3)
+        version: 0.9.9(prettier@3.9.4)(typescript@6.0.3)
       '@astrojs/markdown-remark':
         specifier: ^7.2.1
         version: 7.2.1
@@ -47,9 +47,6 @@ importers:
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
-      commander:
-        specifier: ^13.0.0
-        version: 13.1.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -78,8 +75,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.3
       undici:
         specifier: ^8.7.0
         version: 8.7.0
@@ -1631,10 +1628,6 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
-
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -3221,8 +3214,8 @@ packages:
   typescript-auto-import-cache@0.3.6:
     resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3693,12 +3686,12 @@ snapshots:
 
   '@antfu/utils@8.1.1': {}
 
-  '@astrojs/check@0.9.9(prettier@3.9.4)(typescript@5.9.3)':
+  '@astrojs/check@0.9.9(prettier@3.9.4)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.11(prettier@3.9.4)(typescript@5.9.3)
+      '@astrojs/language-server': 2.16.11(prettier@3.9.4)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs: 17.7.3
     transitivePeerDependencies:
       - prettier
@@ -3771,12 +3764,12 @@ snapshots:
       smol-toml: 1.7.0
       unified: 11.0.5
 
-  '@astrojs/language-server@2.16.11(prettier@3.9.4)(typescript@5.9.3)':
+  '@astrojs/language-server@2.16.11(prettier@3.9.4)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@volar/kit': 2.4.28(typescript@5.9.3)
+      '@volar/kit': 2.4.28(typescript@6.0.3)
       '@volar/language-core': 2.4.28
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
@@ -4822,12 +4815,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@volar/kit@2.4.28(typescript@5.9.3)':
+  '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: 5.9.3
+      typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -5158,8 +5151,6 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
-
-  commander@13.1.0: {}
 
   commander@7.2.0: {}
 
@@ -7272,7 +7263,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,17 @@
+# pnpm settings live here (instead of the `pnpm` field in package.json),
+# which is the supported location since pnpm 10 and required by pnpm 11+.
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd
+
+overrides:
+  'esbuild@<0.25.0': ^0.25.0
+  mermaid-isomorphic: github:silverhand-io/mermaid-isomorphic#c081c30
+  'undici@<6.27.0': ^6.27.0
+  'ws@>=8.0.0 <8.21.0': ^8.21.0
+
+peerDependencyRules:
+  allowedVersions:
+    astro-i18n-aut>astro: ^7.0.0
+    '@astrolib/seo>astro': ^7.0.0


### PR DESCRIPTION
## Summary

Fixes the root cause behind the failing renovate PRs #177 and #179, and completes their updates so they can be closed.

### Why renovate PRs were failing

pnpm 11 recently became `latest` on npm. This repo had no pnpm version constraint, so Renovate used pnpm 11 for lockfile updates — but pnpm 11 no longer reads the `pnpm` field in `package.json` (`overrides`, `onlyBuiltDependencies`, `peerDependencyRules` are all ignored). Renovate's lockfile regeneration failed with an "Artifact update problem", shipping PRs whose `package.json` was bumped but whose lockfile was stale, which then failed CI with `ERR_PNPM_OUTDATED_LOCKFILE`.

### Changes

- Move the `pnpm` settings from `package.json` to `pnpm-workspace.yaml` (the supported location since pnpm 10, required by pnpm 11+). Values are unchanged, so no lockfile churn.
- Add `engines.pnpm: ^10.0.0` so Renovate (and anyone else) resolves lockfile updates with pnpm 10, matching CI.
- Upgrade `typescript` to v6 (supersedes #179; `@astrojs/check` peer range already allows `^6.0.0`).
- Remove `commander` (supersedes #177) — it is not imported anywhere; the translate scripts use `arg`.

Once merged, Renovate should auto-close #177 and #179.

## Testing

tested locally (`pnpm install --frozen-lockfile`, `astro check`, `pnpm test`)

## Checklist

- [x] ~`.changeset`~ N/A
- [x] ~unit tests~ N/A
- [x] ~integration tests~ N/A
- [x] ~necessary TSDoc comments~ N/A