### PR TITLE
feat: add AuthZ shorthand to Authorization article titles

### DIFF
--- a/src/content/terms/ar/authorization.mdx
+++ b/src/content/terms/ar/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: التفويض (Authorization)
+title: التفويض (Authorization, AuthZ)
 tags: [authorization]
 description: التفويض (Authorization) هو عملية تحديد الإجراءات التي يمكن للهوية القيام بها على مورد ما. يعتبر آلية أمنية أساسية لتعريف وتطبيق سياسات الوصول.
 ---

--- a/src/content/terms/de/authorization.mdx
+++ b/src/content/terms/de/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorisierung (Authorization)
+title: Autorisierung (Authorization, AuthZ)
 tags: [authorization]
 description: Autorisierung (Authorization) ist der Prozess der Bestimmung, welche Aktionen eine Identität auf einer Ressource ausführen kann. Es ist ein grundlegender Sicherheitsmechanismus, um Zugriffsrichtlinien zu definieren und durchzusetzen.
 ---

--- a/src/content/terms/en/authorization.mdx
+++ b/src/content/terms/en/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Authorization
+title: Authorization (AuthZ)
 tags: [authorization]
 description: Authorization is the process of determining what actions an identity can perform on a resource. It is a fundamental security mechanism to define and enforce access policies.
 ---

--- a/src/content/terms/es/authorization.mdx
+++ b/src/content/terms/es/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorización (Authorization)
+title: Autorización (Authorization, AuthZ)
 tags: [authorization]
 description: La autorización es el proceso de determinar qué acciones puede realizar una identidad en un recurso. Es un mecanismo de seguridad fundamental para definir y hacer cumplir políticas de acceso.
 ---

--- a/src/content/terms/fr/authorization.mdx
+++ b/src/content/terms/fr/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorisation (Authorization)
+title: Autorisation (Authorization, AuthZ)
 tags: [authorization]
 description: L'autorisation est le processus de détermination des actions qu'une identité peut effectuer sur une ressource. C'est un mécanisme de sécurité fondamental pour définir et appliquer des politiques d'accès.
 ---

--- a/src/content/terms/it/authorization.mdx
+++ b/src/content/terms/it/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorizzazione
+title: Autorizzazione (Authorization, AuthZ)
 tags: [authorization]
 description: L'autorizzazione è il processo di determinare quali azioni un'identità può eseguire su una risorsa. È un meccanismo di sicurezza fondamentale per definire e applicare le politiche di accesso.
 ---

--- a/src/content/terms/ja/authorization.mdx
+++ b/src/content/terms/ja/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: 認可 (Authorization)
+title: 認可 (Authorization, AuthZ)
 tags: [authorization]
 description: 認可 (Authorization) は、あるアイデンティティがリソース上でどのようなアクションを実行できるかを決定するプロセスです。アクセス ポリシーを定義し、適用するための基本的なセキュリティ メカニズムです。
 ---

--- a/src/content/terms/ko/authorization.mdx
+++ b/src/content/terms/ko/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: 권한 부여 (Authorization)
+title: 권한 부여 (Authorization, AuthZ)
 tags: [authorization]
 description: 권한 부여 (Authorization)는 한 정체성이 리소스에서 어떤 작업을 수행할 수 있는지를 결정하는 과정입니다. 이는 접근 정책을 정의하고 시행하는 기본적인 보안 메커니즘입니다.
 ---

--- a/src/content/terms/nl/authorization.mdx
+++ b/src/content/terms/nl/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorisatie (Authorization)
+title: Autorisatie (Authorization, AuthZ)
 tags: [authorization]
 description: Autorisatie (Authorization) is het proces van het bepalen welke acties een identiteit kan uitvoeren op een bron. Het is een fundamenteel beveiligingsmechanisme om toegangsbeleid te definiëren en af te dwingen.
 ---

--- a/src/content/terms/pt-br/authorization.mdx
+++ b/src/content/terms/pt-br/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorização (Authorization)
+title: Autorização (Authorization, AuthZ)
 tags: [authorization]
 description: Autorização (Authorization) é o processo de determinar quais ações uma identidade pode realizar em um recurso. É um mecanismo de segurança fundamental para definir e aplicar políticas de acesso.
 ---

--- a/src/content/terms/pt-pt/authorization.mdx
+++ b/src/content/terms/pt-pt/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Autorização (Authorization)
+title: Autorização (Authorization, AuthZ)
 tags: [authorization]
 description: A autorização (Authorization) é o processo de determinar quais ações uma identidade pode realizar em um recurso. É um mecanismo de segurança fundamental para definir e aplicar políticas de acesso.
 ---

--- a/src/content/terms/zh-Hant/authorization.mdx
+++ b/src/content/terms/zh-Hant/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: 授權 (Authorization)
+title: 授權 (Authorization, AuthZ)
 tags: [authorization]
 description: 授權 (Authorization) 是確定一個身份可以在資源上執行哪些操作的過程。這是一種基本的安全機制，用於定義和實施訪問策略。
 ---

--- a/src/content/terms/zh/authorization.mdx
+++ b/src/content/terms/zh/authorization.mdx
@@ -1,5 +1,5 @@
 ---
-title: 授权 (Authorization)
+title: 授权 (Authorization, AuthZ)
 tags: [authorization]
 description: 授权 (Authorization) 是确定一个身份对资源可以执行哪些操作的过程。它是定义和强制执行访问策略的基本安全机制。
 ---


### PR DESCRIPTION
## Summary

Closes #127.

The **Authentication** article title already includes the shorthand `AuthN` (e.g. `Authentication (AuthN)`), but the **Authorization** article had no matching `AuthZ` shorthand. This makes the two articles inconsistent and makes it harder for readers searching for "AuthZ" to find the page.

This PR adds the `AuthZ` shorthand to the `Authorization` article title across all 13 locales, following the existing per-locale pattern used for `AuthN`:

- English: `Authorization` → `Authorization (AuthZ)`
- Localized: `... (Authorization)` → `... (Authorization, AuthZ)`
- Italian, which was missing the English gloss entirely, is normalized to `Autorizzazione (Authorization, AuthZ)`

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
